### PR TITLE
Resource Fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,8 @@ def setup_package():
         long_description = "\n".join(DOCLINES[2:]),
         version = get_version_info(),
         package_dir = {'': 'src'},
-        packages = ['plotypus', 'plotypus.resources'], 
-        package_data = {'plotypus': ['resources/matplotlibrc']}, 
+        packages = ['plotypus', 'plotypus.resources'],
+        package_data = {'plotypus': ['resources/matplotlibrc']},
         entry_points = {
             'console_scripts': [
                 'plotypus = plotypus.plotypus:main'


### PR DESCRIPTION
I believe I have fixed the bug which prevented resources (namely, the provided `matplotlibrc` file) from being accessed under certain types of installs.

I also used this to test out the branch/pull request workflow, and as you can see from the title of this branch (`nil`), I still have learning to do.
