### PR TITLE
Pandas data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,10 +60,11 @@ def setup_package():
         ],
         classifiers=[f for f in CLASSIFIERS.split('\n') if f],
         install_requires=[
-            'numpy>=1.6.0',
-            'scipy>=0.9.0',
             'matplotlib>=1.3.0',
-            'scikit-learn>=0.14.0'
+            'numpy>=1.6.0',
+            'pandas>=0.13.0',
+            'scikit-learn>=0.14.0',
+            'scipy>=0.9.0'
         ]
     )
 


### PR DESCRIPTION
Currently we accept two arguments `--periods=FILE` and `--shifts=FILE` when the user would like to pass in pre-determined periods and shifts. These arguments are overloaded, in that they also accept a single number to use for all stars.

The latter behaviour has been preserved, although the options have been renamed to `--period` and `--shift`, as they take a single number (although that will change in the multiple periods release).

The former behaviour has been merged into a single argument `--parameters`, which takes a single file containing a table, whose first column contains star names, and other columns may contain anything. These columns must be labeled (although the names column is optional), and if a column for Period or Shift is given, it will be used for the star. By default, the column name must be `"Period"` or `"Shift"`, but the command line arguments `--period-label=LABEL` and `--shift-label=LABEL` may override this behaviour.