### PR TITLE
Tikz plot

### DIFF
--- a/src/plotypus/lightcurve.py
+++ b/src/plotypus/lightcurve.py
@@ -445,8 +445,7 @@ def plot_lightcurve_mpl(name, lightcurve, period, data,
     """plot_lightcurve(name, lightcurve, period, data, output='.', legend=False, color=True, n_phases=100, err_const=0.005, **kwargs)
 
     Save a plot of the given *lightcurve* to directory *output*, and return the
-    resulting plot object. Type of object and output format depend on *engine*
-    provided.
+    resulting plot object.
 
     **Parameters**
 
@@ -476,52 +475,59 @@ def plot_lightcurve_mpl(name, lightcurve, period, data,
         Matplotlib Figure object which contains the plot.
     """
     phases = numpy.linspace(0, 1, n_phases, endpoint=False)
-    ax = plt.gca()
+
+    # initialize Figure and Axes objects
+    fig, ax = plt.subplots()
+
+    # format the x- and y-axis
     ax.invert_yaxis()
-    plt.xlim(0,2)
+    ax.set_xlim(0,2)
 
     # Plot points used
     phase, mag, *err = get_signal(data).T
 
     error = err[0] if err else mag*err_const
 
-    inliers = plt.errorbar(numpy.hstack((phase,1+phase)),
-                           numpy.hstack((mag, mag)),
-                           yerr=numpy.hstack((error, error)),
-                           ls='None',
-                           ms=.01, mew=.01, capsize=0)
+    inliers = ax.errorbar(numpy.hstack((phase,1+phase)),
+                          numpy.hstack((mag, mag)),
+                          yerr=numpy.hstack((error, error)),
+                          ls='None',
+                          ms=.01, mew=.01, capsize=0)
 
     # Plot outliers rejected
     phase, mag, *err = get_noise(data).T
 
     error = err[0] if err else mag*err_const
 
-    outliers = plt.errorbar(numpy.hstack((phase,1+phase)),
-                            numpy.hstack((mag, mag)),
-                            yerr=numpy.hstack((error, error)),
-                            ls='None', marker='o' if color else 'x',
-                            ms=.01 if color else 4,
-                            mew=.01 if color else 1,
-                            capsize=0 if color else 1)
+    outliers = ax.errorbar(numpy.hstack((phase,1+phase)),
+                           numpy.hstack((mag, mag)),
+                           yerr=numpy.hstack((error, error)),
+                           ls='None', marker='o' if color else 'x',
+                           ms=.01 if color else 4,
+                           mew=.01 if color else 1,
+                           capsize=0 if color else 1)
 
     # Plot the fitted light curve
-    signal, = plt.plot(numpy.hstack((phases,1+phases)),
-                       numpy.hstack((lightcurve, lightcurve)),
-                       linewidth=1)
+    signal, = ax.plot(numpy.hstack((phases,1+phases)),
+                      numpy.hstack((lightcurve, lightcurve)),
+                      linewidth=1)
 
     if legend:
-        plt.legend([signal, inliers, outliers],
-                   ["Light Curve", "Inliers", "Outliers"],
-                   loc='best')
+        ax.legend([signal, inliers, outliers],
+                  ["Light Curve", "Inliers", "Outliers"],
+                  loc='best')
 
-    plt.xlabel('Phase ({0:0.7} day period)'.format(period))
-    plt.ylabel('Magnitude')
+    ax.set_xlabel('Phase ({0:0.7} day period)'.format(period))
+    ax.set_ylabel('Magnitude')
 
-    plt.title(utils.sanitize_latex(name) if sanitize_latex else name)
-    plt.tight_layout(pad=0.1)
+    ax.set_title(utils.sanitize_latex(name) if sanitize_latex else name)
+    fig.tight_layout(pad=0.1)
+
     make_sure_path_exists(output)
-    plt.savefig(path.join(output, name))
-    plt.clf()
+    fig.savefig(path.join(output, name))
+
+    return fig
+
 
 def plot_lightcurve_tikz(name, lightcurve, period, data,
                         output='.', legend=False, sanitize_latex=False,

--- a/src/plotypus/lightcurve.py
+++ b/src/plotypus/lightcurve.py
@@ -28,7 +28,9 @@ __all__ = [
     'get_lightcurve',
     'get_lightcurve_from_file',
     'find_outliers',
-    'plot_lightcurve'
+    'plot_lightcurve',
+    'plot_lightcurve_mpl',
+    'plot_lightcurve_tikz'
 ]
 
 
@@ -408,14 +410,43 @@ def find_outliers(data, predictor, sigma,
     return numpy.tile(numpy.vstack(outliers), data.shape[1])
 
 
-def plot_lightcurve(name, lightcurve, period, data,
-                    output='.', legend=False, sanitize_latex=False,
-                    color=True, n_phases=100,
-                    err_const=0.005,
-                    **kwargs):
+def plot_lightcurve(*args, engine='mpl', **kwargs):
+    """plot_lightcurve(*args, engine='mpl', **kwargs)
+
+    **Parameters**
+
+    engine : str, optional
+        Engine to use for plotting, choices are "mpl" and "tikz"
+        (default "mpl")
+
+    kwargs :
+        See :func:`plot_lightcurve_mpl` and :func:`plot_lightcurve_tikz`,
+        depending on *engine* specified.
+
+    **Returns**
+
+    plot : object
+        Plot object. Type depends on *engine* used. "mpl" engine returns a
+        `matplotlib.pyplot.Figure` object, and "tikz" engine returns a `str`.
+    """
+    if engine == "mpl":
+        return(plot_lightcurve_mpl(*args, **kwargs))
+    elif engine == "tikz":
+        return(plot_lightcurve_tikz(*args, **kwargs))
+    else:
+        raise KeyError("engine '{}' does not exist".format(engine))
+
+
+def plot_lightcurve_mpl(name, lightcurve, period, data,
+                        output='.', legend=False, sanitize_latex=False,
+                        color=True, n_phases=100,
+                        err_const=0.005,
+                        **kwargs):
     """plot_lightcurve(name, lightcurve, period, data, output='.', legend=False, color=True, n_phases=100, err_const=0.005, **kwargs)
 
-    Save a plot of the given *lightcurve* to directory *output*.
+    Save a plot of the given *lightcurve* to directory *output*, and return the
+    resulting plot object. Type of object and output format depend on *engine*
+    provided.
 
     **Parameters**
 
@@ -441,7 +472,8 @@ def plot_lightcurve(name, lightcurve, period, data,
 
     **Returns**
 
-    None
+    plot : matplotlib.pyplot.Figure
+        Matplotlib Figure object which contains the plot.
     """
     phases = numpy.linspace(0, 1, n_phases, endpoint=False)
     ax = plt.gca()
@@ -490,3 +522,43 @@ def plot_lightcurve(name, lightcurve, period, data,
     make_sure_path_exists(output)
     plt.savefig(path.join(output, name))
     plt.clf()
+
+def plot_lightcurve_tikz(name, lightcurve, period, data,
+                        output='.', legend=False, sanitize_latex=False,
+                        color=True, n_phases=100,
+                        err_const=0.005,
+                        **kwargs):
+    """plot_lightcurve(name, lightcurve, period, data, output='.', legend=False, color=True, n_phases=100, err_const=0.005, **kwargs)
+
+    Save a plot of the given *lightcurve* to directory *output*, and return the
+    resulting plot object. Type of object and output format depend on *engine*
+    provided.
+
+    **Parameters**
+
+    name : str
+        Name of the star. Used in filename and plot title.
+    lightcurve : array-like, shape = [n_samples]
+        Fitted lightcurve.
+    period : number
+        Period to phase time by.
+    data : array-like, shape = [n_samples, 2] or [n_samples, 3]
+        Photometry array containing columns *time*, *magnitude*, and
+        (optional) *error*. *time* should be unphased.
+    output : str, optional
+        Directory to save plot to (default '.').
+    legend : boolean, optional
+        Whether or not to display legend on plot (default False).
+    color : boolean, optional
+        Whether or not to display color in plot (default True).
+    n_phases : integer, optional
+        Number of phase points in fit (default 100).
+    err_const : number, optional
+        Constant to use in absence of error (default 0.005).
+
+    **Returns**
+
+    plot : matplotlib.pyplot.Figure
+        Matplotlib Figure object which contains the plot.
+    """
+    pass

--- a/src/plotypus/lightcurve.py
+++ b/src/plotypus/lightcurve.py
@@ -588,9 +588,8 @@ def plot_lightcurve_tikz(name, lightcurve, period, phased_data, coefficients,
         ymin=%s,
         ymax=%s,
         ytick={%s},
-        y dir=reverse,
-        axis x line*=bottom,
-        axis y line*=left
+        ylabel={Magnitude},
+        y dir=reverse
     ]
     \addplot[
         domain=0:2,

--- a/src/plotypus/plotypus.py
+++ b/src/plotypus/plotypus.py
@@ -93,6 +93,12 @@ def get_args():
         default=1, metavar='N',
         help='minimum number of observation needed to avoid skipping a star '
              '(default = 1)')
+    general_group.add_argument('--plot-engine', type=str,
+        default='mpl', choices=['mpl', 'tikz'],
+        metavar='ENGINE',
+        help='engine to use for plotting. mpl will output image formats, while '
+             'tikz will output tikz source code for use in LaTeX '
+             '(default = "mpl")')
     general_group.add_argument('--matplotlibrc', type=str,
         default=matplotlibrc,
         metavar='RC',
@@ -337,6 +343,7 @@ def process_star(filename, output_plot_lightcurve,
                  *,
                  extension, star_name, period, shift,
                  parameters, period_label, shift_label,
+                 plot_engine,
                  **kwargs):
     """Processes a star's lightcurve, prints its coefficients, and saves
     its plotted lightcurve to a file. Returns the result of get_lightcurve.
@@ -368,6 +375,7 @@ def process_star(filename, output_plot_lightcurve,
     if output_plot_lightcurve is not None:
         plot_lightcurve(star_name, result['lightcurve'], result['period'],
                         result['phased_data'], output=output_plot_lightcurve,
+                        engine=plot_engine,
                         **kwargs)
 
     return result
@@ -400,7 +408,7 @@ def _print_star(result, max_degree, form, fmt, sep):
 
     max_degree = numpy.trim_zeros(coefs[1::2], 'b').size
     n_params   = numpy.count_nonzero(coefs[1::2])
-    
+
     # print the entry for the star with tabs as separators
     # and itertools.chain to separate the different results into a
     # continuous list which is then unpacked

--- a/src/plotypus/plotypus.py
+++ b/src/plotypus/plotypus.py
@@ -376,10 +376,13 @@ def process_star(filename, output_plot_lightcurve,
     if result is None:
         return
     if output_plot_lightcurve is not None:
-        plot = plot_lightcurve(star_name,
-            result['lightcurve'], result['period'], result['phased_data'],
-            output=output_plot_lightcurve, engine=plot_engine,
-            **kwargs)
+        # cannot unpack two dicts in Python <3.5, so we must join the two dicts
+        # we wish to unpack.
+        combined_kwargs = dict(kwargs)
+        combined_kwargs.update(result)
+        plot = plot_lightcurve(output=output_plot_lightcurve,
+                               engine=plot_engine,
+                               **combined_kwargs)
         # allow figure to get garbage collected
         if plot_engine == "mpl":
             # Need to use a local import, a top level import had to be avoided,


### PR DESCRIPTION
This pull request adds in the ability to output plots as `TikZ` source code, in addition to `matplotlib` plots. This is controlled by the `--plot-engine={tikz,mpl}` flag for the CLI, and the `engine={tikz,mpl}` keyword argument to `plotypus.lightcurve.plot_lightcurve()`.
