### PR TITLE
Removed native LaTeX rendering option from default matplotlibrc

### DIFF
--- a/src/plotypus/resources/matplotlibrc
+++ b/src/plotypus/resources/matplotlibrc
@@ -26,7 +26,6 @@ font.serif : 'Times'#Latin Modern
 ## TEXT
 
 text.color : black
-text.usetex : True
 
 
 ## AXES


### PR DESCRIPTION
It can still be re-enabled by providing an alternative matplotlibrc file
with the `--matplotlibrc FILE` flag.

This closes issue #67.
