### PR TITLE
Replaced named lambdas with nested def's

### DIFF
--- a/src/plotypus/cli.py
+++ b/src/plotypus/cli.py
@@ -343,9 +343,10 @@ def main():
                              range(2, max_degree+1)))],
               sep=sep)
 
-    printer = lambda result: _print_star(result, max_degree, args.series_form,
-                                         args.format, sep) \
-                             if result is not None else None
+    def printer(result):
+        if result is not None:
+            _print_star(result, max_degree, args.series_form,
+                        args.format, sep)
     pmap(process_star, filepaths, callback=printer,
          processes=args.star_processes, **picklable_args)
 
@@ -449,12 +450,17 @@ def _print_star(result, max_degree, form, fmt, sep):
     if result is None:
         return
 
-    # function which formats one number string according to fmt
-    format_one = lambda x: fmt % x
-    # function which formats every number in a sequence according to fmt
-    format_all = partial(map, format_one)
-    # function which formats result[key] for the list of keys provided
-    format_keys = lambda *keys: format_all(result[key] for key in keys)
+    def format_one(x):
+        """format one number string according to fmt"""
+        return fmt % x
+
+    def format_all(x):
+        """format every number in a sequence according to fmt"""
+        return map(format_one, x)
+
+    def format_keys(*keys):
+        """format result[key] for the list of keys provided"""
+        return format_all(result[key] for key in keys)
 
     # count inliers and outliers
     points   = result['phased_data'][:,0].size

--- a/src/plotypus/lightcurve.py
+++ b/src/plotypus/lightcurve.py
@@ -296,12 +296,13 @@ def get_lightcurve(data, copy=False, name=None,
         if hasattr(predictor, 'best_estimator_') \
         else predictor
 
-    get_score = lambda scoring: predictor.best_score_ \
-        if hasattr(predictor, 'best_score_') \
-        and predictor.scoring == scoring \
-        else cross_val_score(estimator, colvec(phase), mag,
-                             cv=scoring_cv, scoring=scoring,
-                             n_jobs=scoring_processes).mean()
+    def get_score(scoring):
+        if hasattr(predictor, 'best_score_') and predictor.scoring == scoring:
+            return predictor.best_score_
+        else:
+            return cross_val_score(estimator, colvec(phase), mag,
+                                   cv=scoring_cv, scoring=scoring,
+                                   n_jobs=scoring_processes).mean()
 
     return {'name':         name,
             'period':       _period,


### PR DESCRIPTION
According to PEP-8

Good: `def f(x): return 2*x`

Bad: `f = lambda x: 2*x`

We had a few instances of the latter, because I was unaware that nested
`def`'s do not bleed into the outer scope, and thought the former was a
bad practice.
