### PR TITLE
Pickle fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,8 @@ def setup_package():
             'numpy>=1.6.0',
             'pandas>=0.13.0',
             'scikit-learn>=0.14.0',
-            'scipy>=0.9.0'
+            'scipy>=0.9.0',
+            'dill>=0.2.4'
         ]
     )
 

--- a/src/plotypus/lightcurve.py
+++ b/src/plotypus/lightcurve.py
@@ -77,9 +77,11 @@ def make_predictor(regressor=LassoLarsIC(fit_intercept=False),
     out : object with "fit" and "predict" methods
         The created predictor object.
     """
+    # 
     fourier = Fourier(degree_range=fourier_degree, regressor=regressor) \
               if use_baart else Fourier()
-    pipeline = Pipeline([('Fourier', fourier), ('Regressor', regressor)])
+    pipeline = Pipeline([('Fourier', fourier),
+                         ('Regressor', regressor)])
     if use_baart:
         return pipeline
     else:


### PR DESCRIPTION
Python's `pickle` module has the limitation of being unable to serialize certain things, like _lambdas_. The `dill` module was created to fix the shortcomings of `pickle`.

When I added the new output control flow, I used a number of lambdas, without thinking, and broke our multiprocessing abilities. `dill` came to the rescue, and now everything is back to normal. Henceforth, plotypus depends on `dill`, but also has much more freedom with multiprocessing.

I have also added a number of new comments, as plotypus is severely lacking in the comments department.
