### PR TITLE
Unnecessary phasing fix

### DIFF
--- a/src/plotypus/lightcurve.py
+++ b/src/plotypus/lightcurve.py
@@ -302,7 +302,7 @@ def get_lightcurve(data, copy=False, name=None,
     phase, mag, *err = data.T
 
     # Build predicted light curve and residuals
-    lightcurve = predictor.predict([[i] for i in phases])
+    lightcurve = predictor.predict(colvec(phases))
     residuals = prediction_residuals(phase, mag, predictor)
     # determine phase shift for max light, if a specific shift was not provided
     if shift is None:

--- a/src/plotypus/lightcurve.py
+++ b/src/plotypus/lightcurve.py
@@ -286,7 +286,7 @@ def get_lightcurve(data, copy=False, name=None,
         if sigma:
             outliers = find_outliers(rephase(data.data, _period), predictor,
                                      sigma, sigma_clipping)
-            num_outliers = sum(outliers)[0]
+            num_outliers = np.sum(outliers[:,0])
             if num_outliers == 0 or \
                set.issubset(set(np.nonzero(outliers.T[0])[0]),
                             set(np.nonzero(data.mask.T[0])[0])):

--- a/src/plotypus/periodogram.py
+++ b/src/plotypus/periodogram.py
@@ -299,7 +299,7 @@ def rephase(data, period=1.0, shift=0.0, col=0, copy=True):
         Array containing the rephased *data*.
     """
     rephased = np.ma.array(data, copy=copy)
-    rephased[:, col] = get_phase(rephased[:, col], period, shift)
+    rephased.data[:, col] = get_phase(rephased.data[:, col], period, shift)
 
     return rephased
 

--- a/src/plotypus/periodogram.py
+++ b/src/plotypus/periodogram.py
@@ -67,12 +67,13 @@ def Lomb_Scargle(data, precision, min_period, max_period,
     if output_periodogram:
         periods = 2*np.pi/freqs
         period = periods[np.argmax(pgram)]
-        return period, np.column_stack((periods, pgram))
+        pgram = np.column_stack((periods, pgram))
     else:
         freq = freqs[np.argmax(pgram)]
         period = 2*np.pi/freq
-        return period, None
+        pgram = None
 
+    return period, pgram
 
 def conditional_entropy(data, precision, min_period, max_period,
                         xbins=10, ybins=5, period_jobs=1,
@@ -128,11 +129,10 @@ def conditional_entropy(data, precision, min_period, max_period,
     entropies = list(m(partial_job, periods))
 
     period = periods[np.argmin(entropies)]
+    pgram = np.column_stack((periods, entropies)) if output_periodogram \
+                                                else None
 
-    if output_periodogram:
-        return period, np.column_stack((periods, entropies))
-    else:
-        return period, None
+    return period, pgram
 
 
 def CE(period, data, xbins=10, ybins=5):

--- a/src/plotypus/preprocessing.py
+++ b/src/plotypus/preprocessing.py
@@ -3,6 +3,7 @@ Preprocessors to light curve regression.
 """
 import numpy as np
 from numpy import pi
+from sklearn.base import BaseEstimator
 from sklearn.linear_model import LinearRegression
 from sklearn.pipeline import Pipeline
 from .utils import autocorrelation, rowvec
@@ -12,7 +13,7 @@ __all__ = [
 ]
 
 
-class Fourier():
+class Fourier(BaseEstimator):
     r"""
     Transforms observed data from phase-space to Fourier-space.
 
@@ -21,7 +22,7 @@ class Fourier():
     .. math::
         m(t) = A_0 + \sum_{k=1}^n (a_k \sin(k \omega t) + b_k \cos(k \omega t)),
 
-    phased time observations are transformed into a design matrix
+    time observations are transformed into a design matrix
     :math:`\mathbf{X}` by :func:`Fourier.design_matrix`, such that linear
     regression can be used to solve for coefficients
 
@@ -61,16 +62,22 @@ class Fourier():
     degree_range : 2-tuple or None, optional
         Range of allowed *degree*\s to search via :func:`baart_criteria`, or
         None if single provided *degree* is to be used (default None).
+    period : positive number, optional
+        Period to phase data by. Optional at instantiation time, but must be
+        assigned before "fit" or "transform" methods are called.
     regressor : object with "fit" and "transform" methods, optional
         Regression object used for fitting light curve when selecting *degree*
         via :func:`baart_criteria`. Not used otherwise
         (default
         ``sklearn.linear_model.LinearRegression(fit_intercept=False)``).
     """
-    def __init__(self, degree=3, degree_range=None,
+    def __init__(self,
+                 degree=3, degree_range=None,
+                 period=None,
                  regressor=LinearRegression(fit_intercept=False)):
         self.degree = degree
         self.degree_range = degree_range
+        self.period = period
         self.regressor = regressor
 
     def fit(self, X, y=None):
@@ -89,10 +96,12 @@ class Fourier():
 
         self : returns an instance of self
         """
+        _validate_period(self.period)
+
         # if a range of degrees to search were not provided, use Baart's
         # criteria to search for one
         if self.degree_range is not None:
-            self.degree = self.baart_criteria(X, y)
+            self.degree = self.baart_criteria(X, y, self.period)
 
         return self
 
@@ -105,7 +114,7 @@ class Fourier():
         **Parameters**
 
         X : array-like, shape = [n_samples, 1]
-            Column vector of phases.
+            Column vector of times.
         y : None, optional
             Unused argument for conformity (default None).
 
@@ -114,38 +123,43 @@ class Fourier():
         design_matrix : array-like, shape = [n_samples, 2*degree+1]
             Fourier design matrix produced by :func:`Fourier.design_matrix`.
         """
-        return self.design_matrix(rowvec(X), self.degree)
+        _validate_period(self.period)
 
-    def get_params(self, deep=False):
-        """
-        Get parameters for this preprocessor.
+        return self.design_matrix(rowvec(X), self.period, self.degree)
 
-        **Parameters**
+    # def get_params(self, deep=False):
+    #     """
+    #     Get parameters for this preprocessor.
 
-        deep : boolean, optional
-            Only here for scikit-learn compliance. Ignore it (default False).
+    #     **Parameters**
 
-        **Returns**
+    #     deep : boolean, optional
+    #         Only here for scikit-learn compliance. Ignore it (default False).
 
-        params : dict
-            Mapping of parameter name to value.
-        """
-        return {'degree': self.degree}
+    #     **Returns**
 
-    def set_params(self, **params):
-        """
-        Set parameters for this preprocessor.
+    #     params : dict
+    #         Mapping of parameter name to value.
+    #     """
+    #     return {'degree': self.degree,
+    #             'period': self.period}
 
-        **Returns**
+    # def set_params(self, **params):
+    #     """
+    #     Set parameters for this preprocessor.
 
-        self : returns an instance of self
-        """
-        if 'degree' in params:
-            self.degree = params['degree']
+    #     **Returns**
 
-        return self
+    #     self : returns an instance of self
+    #     """
+    #     if 'degree' in params:
+    #         self.degree = params['degree']
+    #     if 'period' in params:
+    #         self.period = params['period']
 
-    def baart_criteria(self, X, y):
+    #     return self
+
+    def baart_criteria(self, X, y, period):
         """
         Returns the optimal Fourier series degree as determined by
         `Baart's Criteria <http://articles.adsabs.harvard.edu/cgi-bin/nph-iarticle_query?1986A%26A...170...59P&amp;data_type=PDF_HIGH&amp;whole_paper=YES&amp;type=PRINTER&amp;filetype=.pdf>`_ [JOP]_.
@@ -168,7 +182,7 @@ class Fourier():
         cutoff = self.baart_tolerance(X)
         # create a simple pipeline for fitting a Fourier series, using the
         # provided regressor
-        pipeline = Pipeline([('Fourier', Fourier()),
+        pipeline = Pipeline([('Fourier', Fourier(period=period)),
                              ('Regressor', self.regressor)])
         # do some probably unnecessary sorting
         sorted_X = np.sort(X, axis=0)
@@ -214,7 +228,7 @@ class Fourier():
         return (2 * (len(X) - 1))**(-1/2)
 
     @staticmethod
-    def design_matrix(phases, degree):
+    def design_matrix(times, period, degree):
         r"""
         Constructs an :math:`N \times 2n+1` matrix of the form:
 
@@ -222,11 +236,11 @@ class Fourier():
 
             \begin{bmatrix}
               1
-            & \sin(1 \cdot 2\pi \cdot \phi_0)
-            & \cos(1 \cdot 2\pi \cdot \phi_0)
+            & \sin(1 \cdot 2\pi \cdot t_0 / P)
+            & \cos(1 \cdot 2\pi \cdot t_0 / P)
             & \ldots
-            & \sin(n \cdot 2\pi \cdot \phi_0)
-            & \cos(n \cdot 2\pi \cdot \phi_0)
+            & \sin(n \cdot 2\pi \cdot t_0 / P)
+            & \cos(n \cdot 2\pi \cdot t_0 / P)
             \\
               \vdots
             & \vdots
@@ -236,22 +250,31 @@ class Fourier():
             & \vdots
             \\
               1
-            & \sin(1 \cdot 2\pi \cdot \phi_N)
-            & \cos(1 \cdot 2\pi \cdot \phi_N)
+            & \sin(1 \cdot 2\pi \cdot t_N / P)
+            & \cos(1 \cdot 2\pi \cdot t_N / P)
             & \ldots
-            & \sin(n \cdot 2\pi \cdot \phi_N)
-            & \cos(n \cdot 2\pi \cdot \phi_N)
+            & \sin(n \cdot 2\pi \cdot t_N / P)
+            & \cos(n \cdot 2\pi \cdot t_N / P)
             \end{bmatrix}
 
         where :math:`n =` *degree*, :math:`N =` *n_samples*, and
-        :math:`\phi_i =` *phases[i]*.
+        :math:`t_i =` *times[i]*.
 
-        Parameters
-        ----------
-        phases : array-like, shape = [n_samples]
+        **Parameters**
+
+        times : array-like, shape = [n_samples]
+
+        period : positive number
+
+        degree : positive integer
+
+        **Returns**
+
+        design_matrix : array-like, shape = [n_samples, 2*degree + 1]
 
         """
-        n_samples = phases.size
+        # pre-compute number of samples
+        n_samples = np.size(times)
         # initialize coefficient matrix
         M = np.empty((n_samples, 2*degree+1))
         # indices
@@ -262,14 +285,17 @@ class Fourier():
         # the Nxn matrix now has N copies of the same row, and each row is
         # integer multiples of pi counting from 1 to the degree
         x[:,:] = i*2*np.pi
-        # multiply each row of x by the phases
-        x.T[:,:] *= phases
+        # multiply each row of x by the times
+        x.T[:,:] *= times
+        # divide each element in x by the period
+        x /= period
         # place 1's in the first column of the coefficient matrix
         M[:,0]    = 1
         # the odd indices of the coefficient matrix have sine terms
         M[:,1::2] = np.sin(x)
         # the even indices of the coefficient matrix have cosine terms
         M[:,2::2] = np.cos(x)
+
         return M
 
     @staticmethod
@@ -413,3 +439,9 @@ class Fourier():
         phase_deltas   %= 2*pi
 
         return ratios
+
+
+def _validate_period(period):
+    if not np.isscalar(period) or period <= 0:
+        raise ValueError("period must be a positive number, not {}"
+                         .format(period))

--- a/src/plotypus/preprocessing.py
+++ b/src/plotypus/preprocessing.py
@@ -114,7 +114,7 @@ class Fourier():
         design_matrix : array-like, shape = [n_samples, 2*degree+1]
             Fourier design matrix produced by :func:`Fourier.design_matrix`.
         """
-        return self.design_matrix(np.transpose(X), self.degree)
+        return self.design_matrix(rowvec(X), self.degree)
 
     def get_params(self, deep=False):
         """

--- a/src/plotypus/preprocessing.py
+++ b/src/plotypus/preprocessing.py
@@ -127,38 +127,6 @@ class Fourier(BaseEstimator):
 
         return self.design_matrix(rowvec(X), self.period, self.degree)
 
-    # def get_params(self, deep=False):
-    #     """
-    #     Get parameters for this preprocessor.
-
-    #     **Parameters**
-
-    #     deep : boolean, optional
-    #         Only here for scikit-learn compliance. Ignore it (default False).
-
-    #     **Returns**
-
-    #     params : dict
-    #         Mapping of parameter name to value.
-    #     """
-    #     return {'degree': self.degree,
-    #             'period': self.period}
-
-    # def set_params(self, **params):
-    #     """
-    #     Set parameters for this preprocessor.
-
-    #     **Returns**
-
-    #     self : returns an instance of self
-    #     """
-    #     if 'degree' in params:
-    #         self.degree = params['degree']
-    #     if 'period' in params:
-    #         self.period = params['period']
-
-    #     return self
-
     def baart_criteria(self, X, y, period):
         """
         Returns the optimal Fourier series degree as determined by

--- a/src/plotypus/preprocessing.py
+++ b/src/plotypus/preprocessing.py
@@ -114,7 +114,7 @@ class Fourier():
         design_matrix : array-like, shape = [n_samples, 2*degree+1]
             Fourier design matrix produced by :func:`Fourier.design_matrix`.
         """
-        data = np.dstack((np.array(X).T[0], range(len(X))))[0]
+        data = np.column_stack((X, range(len(X))))
         phase, order = data[data[:,0].argsort()].T
         design_matrix = self.design_matrix(phase, self.degree)
         return design_matrix[order.argsort()]

--- a/src/plotypus/preprocessing.py
+++ b/src/plotypus/preprocessing.py
@@ -204,11 +204,11 @@ class Fourier(BaseEstimator):
 
             \begin{bmatrix}
               1
-            & \sin(1 \cdot 2\pi \cdot t_0 / P)
-            & \cos(1 \cdot 2\pi \cdot t_0 / P)
+            & \sin(1 \omega t_0)
+            & \cos(1 \omega t_0)
             & \ldots
-            & \sin(n \cdot 2\pi \cdot t_0 / P)
-            & \cos(n \cdot 2\pi \cdot t_0 / P)
+            & \sin(n \omega t_0)
+            & \cos(n \omega t_0)
             \\
               \vdots
             & \vdots
@@ -218,14 +218,17 @@ class Fourier(BaseEstimator):
             & \vdots
             \\
               1
-            & \sin(1 \cdot 2\pi \cdot t_N / P)
-            & \cos(1 \cdot 2\pi \cdot t_N / P)
+            & \sin(1 \omega t_N)
+            & \cos(1 \omega t_N)
             & \ldots
-            & \sin(n \cdot 2\pi \cdot t_N / P)
-            & \cos(n \cdot 2\pi \cdot t_N / P)
+            & \sin(n \omega t_N)
+            & \cos(n \omega t_N)
             \end{bmatrix}
 
-        where :math:`n =` *degree*, :math:`N =` *n_samples*, and
+        where
+        :math:`n =` *degree*,
+        :math:`N =` *n_samples*,
+        :math:`\omega = 2 \pi /` *period*, and
         :math:`t_i =` *times[i]*.
 
         **Parameters**
@@ -243,6 +246,8 @@ class Fourier(BaseEstimator):
         """
         # pre-compute number of samples
         n_samples = np.size(times)
+        # convert the period into angular frequency
+        omega = 2*np.pi / period
         # initialize coefficient matrix
         M = np.empty((n_samples, 2*degree+1))
         # indices
@@ -251,12 +256,10 @@ class Fourier(BaseEstimator):
         # sine and cosine terms
         x = np.empty((n_samples, degree))
         # the Nxn matrix now has N copies of the same row, and each row is
-        # integer multiples of pi counting from 1 to the degree
-        x[:,:] = i*2*np.pi
+        # integer multiples the angular frequency counting from 1 to the degree
+        x[:,:] = i * omega
         # multiply each row of x by the times
         x.T[:,:] *= times
-        # divide each element in x by the period
-        x /= period
         # place 1's in the first column of the coefficient matrix
         M[:,0]    = 1
         # the odd indices of the coefficient matrix have sine terms

--- a/src/plotypus/preprocessing.py
+++ b/src/plotypus/preprocessing.py
@@ -114,10 +114,7 @@ class Fourier():
         design_matrix : array-like, shape = [n_samples, 2*degree+1]
             Fourier design matrix produced by :func:`Fourier.design_matrix`.
         """
-        data = np.column_stack((X, range(len(X))))
-        phase, order = data[data[:,0].argsort()].T
-        design_matrix = self.design_matrix(phase, self.degree)
-        return design_matrix[order.argsort()]
+        return self.design_matrix(np.transpose(X), self.degree)
 
     def get_params(self, deep=False):
         """

--- a/src/plotypus/utils.py
+++ b/src/plotypus/utils.py
@@ -3,6 +3,7 @@ from os.path import basename, join, isdir
 from sys import stderr
 from multiprocessing import Pool
 import numbers
+import numpy as np
 from numpy import absolute, concatenate, isscalar, median, resize
 
 __all__ = [
@@ -205,7 +206,10 @@ def colvec(X):
 
     out : array-like, shape = [n_samples, 1]
     """
-    return resize(X, (X.shape[0], 1))
+    if np.ndim(X) != 1:
+        raise ValueError("input array must be a row vector")
+
+    return np.reshape(X, (-1, 1))
 
 
 def rowvec(X):
@@ -221,7 +225,12 @@ def rowvec(X):
 
     out : array-like, shape = [n_samples]
     """
-    return resize(X, (1, X.shape[0]))[0]
+    # a column vector must be 2-dimensional  (ndim(X)     == 2),
+    # and have shape (n_rows, 1)             (shape(X)[1] == 1)
+    if np.ndim(X) != 2 or np.shape(X)[1] != 1:
+        raise ValueError("input array must be a column vector")
+
+    return np.reshape(X, (1, -1))
 
 
 def mad(data, axis=None):


### PR DESCRIPTION
This solves most of the problem described in #77. I'm stealing the description of this pull request from the commit that contains most of the changes.

The main point of this commit was to deal with temporal-space data
instead of phase-space data wherever possible. This was especially
important in the `Fourier` class, to prepare for multiperiodic signal
support. Now the period needs to be provided to `Fourier` before
`Fourier.fit` or `Fourier.transform` is called. To allow for setting the
`period` parameter properly when `Fourier` is nested within another
estimator, I had to make `Fourier` a subclass of scikit-learn's
`BaseEstimator`, which we should have done long ago.

Most of the changes in `get_lightcurve` deal with replacing `phase` with
`time`. There are also some changes which deal with providing the
correct data when dealing with masked arrays. There is also a new piece
of code which passes the period into the `Fourier` object, which
required a little bit of hackery (see the comments before the call to
`predictor.set_params`).

The `rephase` function in `plotypus.periodogram` was also modified, such
that masked values are still rephased.
