### PR TITLE
Regressor generalization

### DIFF
--- a/src/plotypus/cli.py
+++ b/src/plotypus/cli.py
@@ -293,20 +293,17 @@ def get_args():
         help='form of Fourier series to use in coefficient output, '
              'does not affect the fit '
              '(default = "cos")')
-    fourier_group.add_argument('--max-iter', type=int,
-        default=1000, metavar='N',
-        help='maximum number of iterations in the regularization path '
-             '(default = 1000)')
-    fourier_group.add_argument('--regularization-cv', type=int,
-        default=None, metavar='N',
-        help='number of folds used in regularization regularization_cv '
-             'validation '
-             '(default = 3)')
 
     ## Regressor Group #######################################################
 
-    regressor_group.add_argument("--regressor-options", type=str, nargs="+",
-        default=[],)
+    regressor_group.add_argument('--regressor-options', type=str, nargs='+',
+        default=[],
+        help='list of key value pairs to pass to regressor object. '
+             'accepted keys depend on regressor. '
+             'values which form valid Python literals (e.g. 2, True, [1,2]) '
+             'are all parsed to their obvious type, or left as strings '
+             'otherwise '
+             '(default = None)')
 
     ## Outlier Group #########################################################
 

--- a/src/plotypus/cli.py
+++ b/src/plotypus/cli.py
@@ -277,12 +277,6 @@ def get_args():
         default=(2, 20), metavar=('MIN', 'MAX'),
         help='range of degrees of fourier fits to use '
              '(default = 2 20)')
-    fourier_group.add_argument('-r', '--regressor', type=import_name,
-        default=sklearn.linear_model.LassoLarsIC,
-        help='type of regressor to use, loads any Python object named like '
-             '*module.submodule.etc.object_name*, though it must behave like a '
-             'scikit-learn regressor '
-             '(default = "sklearn.linear_model.LassoLarsIC")')
     fourier_group.add_argument('--selector',
         choices=['Baart', 'GridSearch'],
         default='GridSearch',
@@ -296,6 +290,12 @@ def get_args():
 
     ## Regressor Group #######################################################
 
+    fourier_group.add_argument('-r', '--regressor', type=import_name,
+        default=sklearn.linear_model.LassoLarsIC,
+        help='type of regressor to use, loads any Python object named like '
+             '*module.submodule.etc.object_name*, though it must behave like a '
+             'scikit-learn regressor '
+             '(default = "sklearn.linear_model.LassoLarsIC")')
     regressor_group.add_argument('--regressor-options', type=str, nargs='+',
         default=[], metavar="KEY VALUE",
         help='list of key value pairs to pass to regressor object. '

--- a/src/plotypus/cli.py
+++ b/src/plotypus/cli.py
@@ -297,7 +297,7 @@ def get_args():
     ## Regressor Group #######################################################
 
     regressor_group.add_argument('--regressor-options', type=str, nargs='+',
-        default=[],
+        default=[], metavar="KEY VALUE",
         help='list of key value pairs to pass to regressor object. '
              'accepted keys depend on regressor. '
              'values which form valid Python literals (e.g. 2, True, [1,2]) '

--- a/src/plotypus/periodogram.py
+++ b/src/plotypus/periodogram.py
@@ -299,7 +299,7 @@ def rephase(data, period=1.0, shift=0.0, col=0, copy=True):
         Array containing the rephased *data*.
     """
     rephased = np.ma.array(data, copy=copy)
-    rephased[:, col] = get_phase(rephased[:, col], period, shift)
+    rephased.data[:, col] = get_phase(rephased.data[:, col], period, shift)
 
     return rephased
 

--- a/src/plotypus/preprocessing.py
+++ b/src/plotypus/preprocessing.py
@@ -3,6 +3,7 @@ Preprocessors to light curve regression.
 """
 import numpy as np
 from numpy import pi
+from sklearn.base import BaseEstimator
 from sklearn.linear_model import LinearRegression
 from sklearn.pipeline import Pipeline
 from .utils import autocorrelation, rowvec
@@ -12,7 +13,7 @@ __all__ = [
 ]
 
 
-class Fourier():
+class Fourier(BaseEstimator):
     r"""
     Transforms observed data from phase-space to Fourier-space.
 
@@ -21,7 +22,7 @@ class Fourier():
     .. math::
         m(t) = A_0 + \sum_{k=1}^n (a_k \sin(k \omega t) + b_k \cos(k \omega t)),
 
-    phased time observations are transformed into a design matrix
+    time observations are transformed into a design matrix
     :math:`\mathbf{X}` by :func:`Fourier.design_matrix`, such that linear
     regression can be used to solve for coefficients
 
@@ -61,16 +62,22 @@ class Fourier():
     degree_range : 2-tuple or None, optional
         Range of allowed *degree*\s to search via :func:`baart_criteria`, or
         None if single provided *degree* is to be used (default None).
+    period : positive number, optional
+        Period to phase data by. Optional at instantiation time, but must be
+        assigned before "fit" or "transform" methods are called.
     regressor : object with "fit" and "transform" methods, optional
         Regression object used for fitting light curve when selecting *degree*
         via :func:`baart_criteria`. Not used otherwise
         (default
         ``sklearn.linear_model.LinearRegression(fit_intercept=False)``).
     """
-    def __init__(self, degree=3, degree_range=None,
+    def __init__(self,
+                 degree=3, degree_range=None,
+                 period=None,
                  regressor=LinearRegression(fit_intercept=False)):
         self.degree = degree
         self.degree_range = degree_range
+        self.period = period
         self.regressor = regressor
 
     def fit(self, X, y=None):
@@ -89,10 +96,12 @@ class Fourier():
 
         self : returns an instance of self
         """
+        _validate_period(self.period)
+
         # if a range of degrees to search were not provided, use Baart's
         # criteria to search for one
         if self.degree_range is not None:
-            self.degree = self.baart_criteria(X, y)
+            self.degree = self.baart_criteria(X, y, self.period)
 
         return self
 
@@ -105,7 +114,7 @@ class Fourier():
         **Parameters**
 
         X : array-like, shape = [n_samples, 1]
-            Column vector of phases.
+            Column vector of times.
         y : None, optional
             Unused argument for conformity (default None).
 
@@ -114,38 +123,43 @@ class Fourier():
         design_matrix : array-like, shape = [n_samples, 2*degree+1]
             Fourier design matrix produced by :func:`Fourier.design_matrix`.
         """
-        return self.design_matrix(rowvec(X), self.degree)
+        _validate_period(self.period)
 
-    def get_params(self, deep=False):
-        """
-        Get parameters for this preprocessor.
+        return self.design_matrix(rowvec(X), self.period, self.degree)
 
-        **Parameters**
+    # def get_params(self, deep=False):
+    #     """
+    #     Get parameters for this preprocessor.
 
-        deep : boolean, optional
-            Only here for scikit-learn compliance. Ignore it (default False).
+    #     **Parameters**
 
-        **Returns**
+    #     deep : boolean, optional
+    #         Only here for scikit-learn compliance. Ignore it (default False).
 
-        params : dict
-            Mapping of parameter name to value.
-        """
-        return {'degree': self.degree}
+    #     **Returns**
 
-    def set_params(self, **params):
-        """
-        Set parameters for this preprocessor.
+    #     params : dict
+    #         Mapping of parameter name to value.
+    #     """
+    #     return {'degree': self.degree,
+    #             'period': self.period}
 
-        **Returns**
+    # def set_params(self, **params):
+    #     """
+    #     Set parameters for this preprocessor.
 
-        self : returns an instance of self
-        """
-        if 'degree' in params:
-            self.degree = params['degree']
+    #     **Returns**
 
-        return self
+    #     self : returns an instance of self
+    #     """
+    #     if 'degree' in params:
+    #         self.degree = params['degree']
+    #     if 'period' in params:
+    #         self.period = params['period']
 
-    def baart_criteria(self, X, y):
+    #     return self
+
+    def baart_criteria(self, X, y, period):
         """
         Returns the optimal Fourier series degree as determined by
         `Baart's Criteria <http://articles.adsabs.harvard.edu/cgi-bin/nph-iarticle_query?1986A%26A...170...59P&amp;data_type=PDF_HIGH&amp;whole_paper=YES&amp;type=PRINTER&amp;filetype=.pdf>`_ [JOP]_.
@@ -168,7 +182,7 @@ class Fourier():
         cutoff = self.baart_tolerance(X)
         # create a simple pipeline for fitting a Fourier series, using the
         # provided regressor
-        pipeline = Pipeline([('Fourier', Fourier()),
+        pipeline = Pipeline([('Fourier', Fourier(period=period)),
                              ('Regressor', self.regressor)])
         # do some probably unnecessary sorting
         sorted_X = np.sort(X, axis=0)
@@ -214,7 +228,7 @@ class Fourier():
         return (2 * (len(X) - 1))**(-1/2)
 
     @staticmethod
-    def design_matrix(phases, degree):
+    def design_matrix(times, period, degree):
         r"""
         Constructs an :math:`N \times 2n+1` matrix of the form:
 
@@ -222,11 +236,11 @@ class Fourier():
 
             \begin{bmatrix}
               1
-            & \sin(1 \cdot 2\pi \cdot \phi_0)
-            & \cos(1 \cdot 2\pi \cdot \phi_0)
+            & \sin(1 \cdot 2\pi \cdot t_0 / P)
+            & \cos(1 \cdot 2\pi \cdot t_0 / P)
             & \ldots
-            & \sin(n \cdot 2\pi \cdot \phi_0)
-            & \cos(n \cdot 2\pi \cdot \phi_0)
+            & \sin(n \cdot 2\pi \cdot t_0 / P)
+            & \cos(n \cdot 2\pi \cdot t_0 / P)
             \\
               \vdots
             & \vdots
@@ -236,22 +250,31 @@ class Fourier():
             & \vdots
             \\
               1
-            & \sin(1 \cdot 2\pi \cdot \phi_N)
-            & \cos(1 \cdot 2\pi \cdot \phi_N)
+            & \sin(1 \cdot 2\pi \cdot t_N / P)
+            & \cos(1 \cdot 2\pi \cdot t_N / P)
             & \ldots
-            & \sin(n \cdot 2\pi \cdot \phi_N)
-            & \cos(n \cdot 2\pi \cdot \phi_N)
+            & \sin(n \cdot 2\pi \cdot t_N / P)
+            & \cos(n \cdot 2\pi \cdot t_N / P)
             \end{bmatrix}
 
         where :math:`n =` *degree*, :math:`N =` *n_samples*, and
-        :math:`\phi_i =` *phases[i]*.
+        :math:`t_i =` *times[i]*.
 
-        Parameters
-        ----------
-        phases : array-like, shape = [n_samples]
+        **Parameters**
+
+        times : array-like, shape = [n_samples]
+
+        period : positive number
+
+        degree : positive integer
+
+        **Returns**
+
+        design_matrix : array-like, shape = [n_samples, 2*degree + 1]
 
         """
-        n_samples = phases.size
+        # pre-compute number of samples
+        n_samples = np.size(times)
         # initialize coefficient matrix
         M = np.empty((n_samples, 2*degree+1))
         # indices
@@ -262,14 +285,17 @@ class Fourier():
         # the Nxn matrix now has N copies of the same row, and each row is
         # integer multiples of pi counting from 1 to the degree
         x[:,:] = i*2*np.pi
-        # multiply each row of x by the phases
-        x.T[:,:] *= phases
+        # multiply each row of x by the times
+        x.T[:,:] *= times
+        # divide each element in x by the period
+        x /= period
         # place 1's in the first column of the coefficient matrix
         M[:,0]    = 1
         # the odd indices of the coefficient matrix have sine terms
         M[:,1::2] = np.sin(x)
         # the even indices of the coefficient matrix have cosine terms
         M[:,2::2] = np.cos(x)
+
         return M
 
     @staticmethod
@@ -413,3 +439,9 @@ class Fourier():
         phase_deltas   %= 2*pi
 
         return ratios
+
+
+def _validate_period(period):
+    if not np.isscalar(period) or period <= 0:
+        raise ValueError("period must be a positive number, not {}"
+                         .format(period))

--- a/src/plotypus/preprocessing.py
+++ b/src/plotypus/preprocessing.py
@@ -127,38 +127,6 @@ class Fourier(BaseEstimator):
 
         return self.design_matrix(rowvec(X), self.period, self.degree)
 
-    # def get_params(self, deep=False):
-    #     """
-    #     Get parameters for this preprocessor.
-
-    #     **Parameters**
-
-    #     deep : boolean, optional
-    #         Only here for scikit-learn compliance. Ignore it (default False).
-
-    #     **Returns**
-
-    #     params : dict
-    #         Mapping of parameter name to value.
-    #     """
-    #     return {'degree': self.degree,
-    #             'period': self.period}
-
-    # def set_params(self, **params):
-    #     """
-    #     Set parameters for this preprocessor.
-
-    #     **Returns**
-
-    #     self : returns an instance of self
-    #     """
-    #     if 'degree' in params:
-    #         self.degree = params['degree']
-    #     if 'period' in params:
-    #         self.period = params['period']
-
-    #     return self
-
     def baart_criteria(self, X, y, period):
         """
         Returns the optimal Fourier series degree as determined by

--- a/src/plotypus/preprocessing.py
+++ b/src/plotypus/preprocessing.py
@@ -204,11 +204,11 @@ class Fourier(BaseEstimator):
 
             \begin{bmatrix}
               1
-            & \sin(1 \cdot 2\pi \cdot t_0 / P)
-            & \cos(1 \cdot 2\pi \cdot t_0 / P)
+            & \sin(1 \omega t_0)
+            & \cos(1 \omega t_0)
             & \ldots
-            & \sin(n \cdot 2\pi \cdot t_0 / P)
-            & \cos(n \cdot 2\pi \cdot t_0 / P)
+            & \sin(n \omega t_0)
+            & \cos(n \omega t_0)
             \\
               \vdots
             & \vdots
@@ -218,14 +218,17 @@ class Fourier(BaseEstimator):
             & \vdots
             \\
               1
-            & \sin(1 \cdot 2\pi \cdot t_N / P)
-            & \cos(1 \cdot 2\pi \cdot t_N / P)
+            & \sin(1 \omega t_N)
+            & \cos(1 \omega t_N)
             & \ldots
-            & \sin(n \cdot 2\pi \cdot t_N / P)
-            & \cos(n \cdot 2\pi \cdot t_N / P)
+            & \sin(n \omega t_N)
+            & \cos(n \omega t_N)
             \end{bmatrix}
 
-        where :math:`n =` *degree*, :math:`N =` *n_samples*, and
+        where
+        :math:`n =` *degree*,
+        :math:`N =` *n_samples*,
+        :math:`\omega = 2 \pi /` *period*, and
         :math:`t_i =` *times[i]*.
 
         **Parameters**
@@ -243,6 +246,8 @@ class Fourier(BaseEstimator):
         """
         # pre-compute number of samples
         n_samples = np.size(times)
+        # convert the period into angular frequency
+        omega = 2*np.pi / period
         # initialize coefficient matrix
         M = np.empty((n_samples, 2*degree+1))
         # indices
@@ -251,12 +256,10 @@ class Fourier(BaseEstimator):
         # sine and cosine terms
         x = np.empty((n_samples, degree))
         # the Nxn matrix now has N copies of the same row, and each row is
-        # integer multiples of pi counting from 1 to the degree
-        x[:,:] = i*2*np.pi
+        # integer multiples the angular frequency counting from 1 to the degree
+        x[:,:] = i * omega
         # multiply each row of x by the times
         x.T[:,:] *= times
-        # divide each element in x by the period
-        x /= period
         # place 1's in the first column of the coefficient matrix
         M[:,0]    = 1
         # the odd indices of the coefficient matrix have sine terms

--- a/src/plotypus/preprocessing.py
+++ b/src/plotypus/preprocessing.py
@@ -74,7 +74,7 @@ class Fourier(BaseEstimator):
     def __init__(self,
                  degree=3, degree_range=None,
                  period=None,
-                 regressor=LinearRegression(fit_intercept=False)):
+                 regressor=LinearRegression()):
         self.degree = degree
         self.degree_range = degree_range
         self.period = period
@@ -203,8 +203,7 @@ class Fourier(BaseEstimator):
         .. math::
 
             \begin{bmatrix}
-              1
-            & \sin(1 \omega t_0)
+              \sin(1 \omega t_0)
             & \cos(1 \omega t_0)
             & \ldots
             & \sin(n \omega t_0)
@@ -212,13 +211,11 @@ class Fourier(BaseEstimator):
             \\
               \vdots
             & \vdots
-            & \vdots
             & \ddots
             & \vdots
             & \vdots
             \\
-              1
-            & \sin(1 \omega t_N)
+              \sin(1 \omega t_N)
             & \cos(1 \omega t_N)
             & \ldots
             & \sin(n \omega t_N)
@@ -241,7 +238,7 @@ class Fourier(BaseEstimator):
 
         **Returns**
 
-        design_matrix : array-like, shape = [n_samples, 2*degree + 1]
+        design_matrix : array-like, shape = [n_samples, 2*degree]
 
         """
         # pre-compute number of samples
@@ -249,7 +246,7 @@ class Fourier(BaseEstimator):
         # convert the period into angular frequency
         omega = 2*np.pi / period
         # initialize coefficient matrix
-        M = np.empty((n_samples, 2*degree+1))
+        M = np.empty((n_samples, 2*degree))
         # indices
         i = np.arange(1, degree+1)
         # initialize the Nxn matrix that is repeated within the
@@ -260,12 +257,10 @@ class Fourier(BaseEstimator):
         x[:,:] = i * omega
         # multiply each row of x by the times
         x.T[:,:] *= times
-        # place 1's in the first column of the coefficient matrix
-        M[:,0]    = 1
-        # the odd indices of the coefficient matrix have sine terms
-        M[:,1::2] = np.sin(x)
-        # the even indices of the coefficient matrix have cosine terms
-        M[:,2::2] = np.cos(x)
+        # the even indices of the coefficient matrix have sine terms
+        M[:,0::2] = np.sin(x)
+        # the odd indices of the coefficient matrix have cosine terms
+        M[:,1::2] = np.cos(x)
 
         return M
 

--- a/src/plotypus/utils.py
+++ b/src/plotypus/utils.py
@@ -8,6 +8,8 @@ from numpy import absolute, concatenate, isscalar, median, resize
 
 __all__ = [
     'verbose_print',
+    'literal_eval_str',
+    'strlist_to_dict',
     'pmap',
     'make_sure_path_exists',
     'valid_basename',
@@ -43,6 +45,61 @@ def verbose_print(message, *, operation, verbosity):
     if (verbosity is not None) and ((operation in verbosity) or
                                     ("all"     in verbosity)):
         print(message, file=stderr)
+
+
+def literal_eval_str(string):
+    """literal_eval_str(string)
+
+    Equivalent to *ast.literal_eval*, but if *string* cannot be parsed,
+    returns the original string. Only accepts arguments of type *str*.
+
+    **Parameters**
+
+    string : str
+        Any string. If it can be parsed as a basic Python object literal, it
+        will be. See *ast.literal_eval* for supported objects.
+
+    **Returns**
+
+    obj : object
+        Original string, or the object literal it represents.
+    """
+    if not isinstance(string, str):
+        raise ValueError("input must be of type str")
+
+    try:
+        from ast import literal_eval
+        return literal_eval(string)
+    except ValueError:
+        return string
+
+
+def strlist_to_dict(lst):
+    """list_to_dict(lst)
+
+    Turn a list of strings with an even number of elements into a dictionary.
+    Any values which may be interpreted as basic Python object literals are
+    parsed as such. See *plotypus.literal_eval_str* for supported types.
+
+    **Parameters**
+
+    lst : list
+        A *list* or equivalent object with an even number of arguments, to be
+        interpreted as *[key1, val1, ..., keyN, valN]*.
+
+    **Returns**
+
+    dct : dict
+        A *dict* whose keys are the even elements of *lst* and values are the
+        odd elements.
+    """
+    if len(lst)%2:
+        raise ValueError("length of list must be even")
+
+    keys = lst[0::2]
+    vals = map(literal_eval_str, lst[1::2])
+
+    return dict(zip(keys, vals))
 
 
 def pmap(func, args, processes=None, callback=lambda *_, **__: None, **kwargs):


### PR DESCRIPTION
This resolves issue #90, and the regressor-specific portion of #91.

It removes the hand-chosen regressor objects, such as `--regressor LassoCV`, and replaces them with the ability to specify _any_ regressor. So the above call would need to be more verbose: `--regressor sklearn.linear_model.LassoCV`, but in exchange for some verbosity, we gain complete generality. This is implemented with `plotypus.utils.import_name`.

This also removes the `--max-iter` and `--regularization-cv` options, which were passed to specific regressors, and instead implements a catch-all `--regressor-options KEY VALUE ... KEY VALUE` option. This allows the user to provide _any_ option to their regressor, provided `VALUE` is a simple Python literal (parsable by the standard library function `ast.literal_eval` or a string. Value parsing is implemented with `plotypus.utils.literal_eval_str`, and conversion to a `dict` is done with `plotypus.utils.strlist_to_dict`.

Because of these changes, we could no longer assume that `fit_intercept=False` on the regressors. In fact, it is most likely that `fit_intercept=True`, as that is the default for every scikit-learn regressor that I know of. For this reason, I have removed the one's column from `preprocessing.Fourier.design_matrix`, and `get_lightcurve` now takes the `A_0` term from the regressor's `intercept_` attribute.
